### PR TITLE
Fix for : Error: Input required and not supplied: distribution 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,9 @@ jobs:
         ionic start testapp blank --cordova --type angular --no-link --no-git --no-interactive --confirm
         cd testapp
     - name: Adding Platform Android
-      run: ionic cordova platform add android
+      run:  |
+        cd testapp
+        ionic cordova platform add android
     - name: Removing 31.0.0 Build tool
       run: $ANDROID_SDK_ROOT/tools/bin/sdkmanager --uninstall 'build-tools;31.0.0
     - name: Run cordova project tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,18 +6,21 @@ on: # rebuild any PRs and main branch changes
       - master
 
 jobs:
-  build: # make sure build/ci work properly
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - run: |
-        npm ci
-        npm run all
+#   build: # make sure build/ci work properly
+#     runs-on: ubuntu-latest
+#     steps:
+#     - uses: actions/checkout@v1
+#     - run: |
+#         npm ci
+#         npm run all
         
   test: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 15.x
     - uses: actions/setup-java@v1
       with:
         java-version: 1.8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         npm ci
         npm run all
   test: # make sure the action works on a clean machine without building
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,13 @@ jobs:
        java-version: '8'
     - name: Use coturiv/setup-ionic
       uses: ./
-    - name: Run cordova project tests
+    - name: Create a new Project
       run: |
         ionic start testapp blank --cordova --type angular --no-link --no-git --no-interactive --confirm
         cd testapp
-        ionic cordova platform add android@latest
-        $ANDROID_SDK_ROOT/tools/bin/sdkmanager --uninstall 'build-tools;31.0.0
-        ionic cordova build android
+    - name: Adding Platform Android
+      run: ionic cordova platform add android
+    - name: Removing 31.0.0 Build tool
+      run: $ANDROID_SDK_ROOT/tools/bin/sdkmanager --uninstall 'build-tools;31.0.0
+    - name: Run cordova project tests
+      run: ionic cordova build android

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: "CI"
+name: "CI t"
 on: # rebuild any PRs and main branch changes
   pull_request:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     - run: |
         npm ci
         npm run all
+        
   test: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: "CI t"
+name: "CI"
 on: # rebuild any PRs and main branch changes
   pull_request:
   push:
@@ -6,22 +6,18 @@ on: # rebuild any PRs and main branch changes
       - master
 
 jobs:
-#   build: # make sure build/ci work properly
-#     runs-on: ubuntu-latest
-#     steps:
-#     - uses: actions/checkout@v1
-#     - run: |
-#         npm ci
-#         npm run all
-        
+  build: # make sure build/ci work properly
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: |
+        npm ci
+        npm run all
   test: # make sure the action works on a clean machine without building
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-node@v1
-      with:
-        node-version: 15.x
-    - uses: actions/setup-java@v1
+    - uses: actions/checkout@v2
+    - uses: actions/setup-java@v2
       with:
         java-version: 1.8
     - name: Use coturiv/setup-ionic

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
         cd testapp
         ionic cordova platform add android
     - name: Removing 31.0.0 Build tool
-      run: $ANDROID_SDK_ROOT/tools/bin/sdkmanager --uninstall 'build-tools;31.0.0
+      run: $ANDROID_SDK_ROOT/tools/bin/sdkmanager --uninstall 'build-tools;31.0.0'
     - name: Run cordova project tests
-      run: ionic cordova build android
+      run: |
+        cd testapp
+        ionic cordova build android

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/setup-java@v2
       with:
        distribution: 'adopt' # See 'Supported distributions' for available options
-       java-version: '8'
+       java-version: '11'
     - name: Use coturiv/setup-ionic
       uses: ./
     - name: Run cordova project tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v2
       with:
-        java-version: 1.8
+       distribution: 'adopt' # See 'Supported distributions' for available options
+       java-version: '8'
     - name: Use coturiv/setup-ionic
       uses: ./
     - name: Run cordova project tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,5 @@ jobs:
         ionic start testapp blank --cordova --type angular --no-link --no-git --no-interactive --confirm
         cd testapp
         ionic cordova platform add android@latest
+        $ANDROID_SDK_ROOT/tools/bin/sdkmanager --uninstall 'build-tools;31.0.0
         ionic cordova build android

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/setup-java@v2
       with:
        distribution: 'adopt' # See 'Supported distributions' for available options
-       java-version: '11'
+       java-version: '8'
     - name: Use coturiv/setup-ionic
       uses: ./
     - name: Run cordova project tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         npm ci
         npm run all
   test: # make sure the action works on a clean machine without building
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v2


### PR DESCRIPTION
### Resolution to this workflow issue
Error: Input required and not supplied: distribution 

![image](https://user-images.githubusercontent.com/61633603/126860382-0585e881-e812-4f26-97f5-5c4c22007f72.png)

The use of actions/setup-java@v2 requires you to specify  new mandatory `distribution` input along with the version.

**Referenced links:**

- Official Docs:  https://github.com/actions/setup-java#supported-distributions
- Migartion:  https://github.com/actions/setup-java/blob/main/docs/switching-to-v2.md

